### PR TITLE
Switch tests to unittest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ python3 photo_metadata_patch.py /path/to/export --output /tmp/report.csv
 Basic unit tests are located in the `tests` directory and can be run with:
 
 ```bash
-python3 -m pytest
+python3 -m unittest discover -s tests
 ```

--- a/tests/test_photo_metadata_patch.py
+++ b/tests/test_photo_metadata_patch.py
@@ -1,56 +1,72 @@
 import json
+import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from photo_metadata_patch import index_media_files, load_json_metadata, get_duplicate_type
+
+from photo_metadata_patch import (
+    index_media_files,
+    load_json_metadata,
+    get_duplicate_type,
+)
 
 
-def test_index_media_files():
-    with TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        (root / "a").mkdir()
-        (root / "b").mkdir()
-        file1 = root / "a" / "IMG.JPG"
-        file2 = root / "b" / "img.jpg"
-        file1.touch()
-        file2.touch()
+class TestPhotoMetadataPatch(unittest.TestCase):
+    def test_index_media_files(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "a").mkdir()
+            (root / "b").mkdir()
+            file1 = root / "a" / "IMG.JPG"
+            file2 = root / "b" / "img.jpg"
+            file1.touch()
+            file2.touch()
 
-        index = index_media_files(root, {".jpg"})
-        assert "img.jpg" in index
-        assert len(index["img.jpg"]) == 2
+            index = index_media_files(root, {".jpg"})
+            self.assertIn("img.jpg", index)
+            self.assertEqual(len(index["img.jpg"]), 2)
+
+    def test_load_json_metadata(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            good = root / "good.json"
+            bad = root / "bad.json"
+            good.write_text(json.dumps({"a": 1}))
+            bad.write_text("{ invalid json }")
+
+            self.assertEqual(load_json_metadata(good), {"a": 1})
+            self.assertIsNone(load_json_metadata(bad))
+
+    def test_get_duplicate_type(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "a").mkdir()
+            (root / "b").mkdir()
+            file1 = root / "a" / "IMG.JPG"
+            file2 = root / "b" / "IMG.JPG"
+            file1.touch()
+            file2.touch()
+            meta1 = file1.with_name(file1.name + ".supplemental-metadata.json")
+            meta2 = file2.with_name(file2.name + ".supplemental-metadata.json")
+            meta1.write_text(json.dumps({"url": "A"}))
+            meta2.write_text(json.dumps({"url": "A"}))
+
+            media_index = index_media_files(root, {".jpg"})
+            matches = media_index["img.jpg"]
+            self.assertEqual(
+                get_duplicate_type(matches, "A", media_index), "Exact Duplicate"
+            )
+
+            meta2.write_text(json.dumps({"url": "B"}))
+            self.assertEqual(
+                get_duplicate_type(matches, "A", media_index), "Misleading Duplicate"
+            )
+
+            # unique when only one match
+            self.assertEqual(
+                get_duplicate_type([file1], "A", media_index), "Unique"
+            )
 
 
-def test_load_json_metadata():
-    with TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        good = root / "good.json"
-        bad = root / "bad.json"
-        good.write_text(json.dumps({"a": 1}))
-        bad.write_text("{ invalid json }")
-        assert load_json_metadata(good) == {"a": 1}
-        assert load_json_metadata(bad) is None
-
-
-def test_get_duplicate_type():
-    with TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        (root / "a").mkdir()
-        (root / "b").mkdir()
-        file1 = root / "a" / "IMG.JPG"
-        file2 = root / "b" / "IMG.JPG"
-        file1.touch()
-        file2.touch()
-        meta1 = file1.with_name(file1.name + ".supplemental-metadata.json")
-        meta2 = file2.with_name(file2.name + ".supplemental-metadata.json")
-        meta1.write_text(json.dumps({"url": "A"}))
-        meta2.write_text(json.dumps({"url": "A"}))
-
-        media_index = index_media_files(root, {".jpg"})
-        matches = media_index["img.jpg"]
-        assert get_duplicate_type(matches, "A", media_index) == "Exact Duplicate"
-
-        meta2.write_text(json.dumps({"url": "B"}))
-        assert get_duplicate_type(matches, "A", media_index) == "Misleading Duplicate"
-
-        # unique when only one match
-        assert get_duplicate_type([file1], "A", media_index) == "Unique"
+if __name__ == "__main__":
+    unittest.main()
 


### PR DESCRIPTION
## Summary
- rewrite tests to use `unittest.TestCase`
- add `unittest.main()` entrypoint
- update README instructions for running tests with `python3 -m unittest discover -s tests`
- add `.gitignore` for Python cache files

## Testing
- `python3 -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68740004fc488327a55ead24217d0d12