### PR TITLE
Update AGENTS rules to allow Swift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,35 @@
 ## Thanks for contributing to this repo!
 
-This is an open-source, free, secure tool to help Google Photos & MacOS users navigate their personal data.
+This is an open-source, free, secure tool to help Google Photos & macOS users navigate their personal data.
 
-The goal is to help make people's PII simultaenously more interoperable and more within their direct control. 
+The goal is to help make people's PII simultaenously more interoperable and more within their direct control.
 
 By default, this project has a few hard and fast rules:
 
 - Zero PII exposure.
-- Zero package installs.
+- Zero **Python** package installs.
+- Swift (including SwiftUI) is allowed for macOS Sequoia (macOS 26) or later.
 - Transparent & Human-Readable outputs, changes, and error-logging.
 - Explicit > Implicit. Clean > Clever.
 
-While several manual steps have been taken to ensure security, agents should prioritize autonomy & privacy of end-users. 
+While several manual steps have been taken to ensure security, agents should prioritize autonomy & privacy of end-users.
 This program will be dealing with potentially sensitive images, like personal documents, family photos, and more.
 
 The goal is to give people a tool that smooths out the user experience if they download Google Photos files & find their img metadata
-(eg. "Date Taken: December 31st, 1979") altered. Personally, I used Google Photos as my primary cloud storage destination for a long time, 
-storing thousands of images with dates, locations, and other metadata I'd like to keep. 
+(eg. "Date Taken: December 31st, 1979") altered. Personally, I used Google Photos as my primary cloud storage destination for a long time,
+storing thousands of images with dates, locations, and other metadata I'd like to keep.
 
-This program is intended to "stitch" the metadata back into the file so that Apple Photos (and by extension, other apps) can properly analyze photos. 
+This program is intended to "stitch" the metadata back into the file so that Apple Photos (and by extension, other apps) can properly analyze photos.
 
-Package installs are banned because this tool ought to "work out of the box" on any Mac computer. Extensability to iOS and iPadOS are next. 
+Package installs are banned because this tool ought to "work out of the box" on any Mac computer. This restriction applies to Python.
+Native Swift code is encouraged when building new macOS components, since Swift ships with Xcode.
+Extensability to iOS and iPadOS are next.
 
-Agents should consider the implications of this job: images may contain things like driver's licenses, photos of thier kids, and countless other things.
+Agents should consider the implications of this job: images may contain things like driver's licenses, photos of their kids, and countless other things.
 
-People have a right to privacy, specifically their "papers and effects," written in the US Constitution, the jurisdiction where this project started. 
+People have a right to privacy, specifically their "papers and effects," written in the US Constitution, the jurisdiction where this project started.
 
-Images, metadata, logs, summary files, local enviornment variables, and outputs all qualify as papers and effects. 
+Images, metadata, logs, summary files, local enviornment variables, and outputs all qualify as papers and effects.
 
 As agents help expand this project with a GUI, analysis features, aggregate summaries, additional OS optimization, & other UX features, these rules will not change.
 

--- a/PhotoMetadataGUI.swift
+++ b/PhotoMetadataGUI.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var rootPath: String = ""
+    @State private var outputPath: String = ""
+    @State private var dryRun: Bool = false
+    @State private var workers: Int = 4
+    @State private var statusMessage: String = ""
+    @State private var running: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Google Photos Metadata Patcher")
+                .font(.title2)
+                .bold()
+
+            Form {
+                HStack {
+                    TextField("Export Folder", text: $rootPath)
+                    Button("Browse") { chooseRoot() }
+                }
+                HStack {
+                    TextField("Output CSV (optional)", text: $outputPath)
+                    Button("Save As") { chooseOutput() }
+                }
+                Toggle("Dry Run", isOn: $dryRun)
+                HStack {
+                    Text("Workers")
+                    Stepper(value: $workers, in: 1...16) {
+                        Text("\(workers)")
+                    }
+                }
+                Button("Run") { runProcess() }
+                    .disabled(running || rootPath.isEmpty)
+            }
+            if !statusMessage.isEmpty {
+                Text(statusMessage)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(20)
+        .frame(width: 450)
+    }
+
+    private func chooseRoot() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        if panel.runModal() == .OK {
+            rootPath = panel.url?.path ?? ""
+        }
+    }
+
+    private func chooseOutput() {
+        let panel = NSSavePanel()
+        panel.allowedFileTypes = ["csv"]
+        if panel.runModal() == .OK {
+            outputPath = panel.url?.path ?? ""
+        }
+    }
+
+    private func runProcess() {
+        running = true
+        statusMessage = "Running..."
+
+        let script = Bundle.main.resourceURL!
+            .appendingPathComponent("photo_metadata_patch.py").path
+
+        var args = [script, rootPath, "--workers", "\(workers)"]
+        if dryRun { args.append("--dry-run") }
+        if !outputPath.isEmpty { args += ["--output", outputPath] }
+
+        DispatchQueue.global().async {
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            task.arguments = ["python3"] + args
+
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.standardError = pipe
+
+            do {
+                try task.run()
+                task.waitUntilExit()
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: data, encoding: .utf8) ?? ""
+                DispatchQueue.main.async {
+                    self.statusMessage = output.isEmpty ? "Done" : output
+                    self.running = false
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.statusMessage = "Failed to run script: \(error.localizedDescription)"
+                    self.running = false
+                }
+            }
+        }
+    }
+}
+
+@main
+struct PhotoMetadataApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .windowStyle(.titleBar)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ python3 photo_metadata_patch.py /path/to/export --output /tmp/report.csv
 ```
 
 ## GUI Launcher
-For a simple graphical front end, double-click the `launch_gui.command` file on macOS.
-It opens a small window where you choose your export folder and optionally where to save the CSV report.
-Ensure the photos are not open in other applications so Finder does not lock the files while they are being updated.
+### Tkinter
+Double‑click the `launch_gui.command` file for the original Tkinter interface. It lets you choose the export folder and optional CSV destination. Make sure your photos aren’t open in other apps so Finder doesn’t lock them.
 
-The GUI requires the same Python and `exiftool` dependencies as the command-line version.
+### SwiftUI
+For a macOS‑native interface built with SwiftUI, open `PhotoMetadataGUI.swift` in Xcode (macOS Sequoia or later) and run the app. The Swift version mirrors the Python GUI and invokes `photo_metadata_patch.py` behind the scenes.
 
 ## Testing
 Basic unit tests are located in the `tests` directory and can be run with:


### PR DESCRIPTION
## Summary
- update `AGENTS.md` to clarify that Swift and SwiftUI are allowed
- retain zero Python package policy, explicitly mention macOS Sequoia

## Testing
- `python3 -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687496bde9e88327b6f64ee19426b078