### PR TITLE
Fix exiftool timestamp quoting

### DIFF
--- a/photo_metadata_patch.py
+++ b/photo_metadata_patch.py
@@ -212,14 +212,14 @@ def process_metadata_files(project_root, dry_run=True, parallel_workers=4, outpu
 
             if ext in {'.mp4', '.mov'}:
                 cmd += [
-                    f'-QuickTime:CreateDate="{dt}',
-                    f'-Keys:CreationDate="{dt}',
-                    f'-UserData:Comment="{comment}'
+                    f'-QuickTime:CreateDate="{dt}"',
+                    f'-Keys:CreationDate="{dt}"',
+                    f'-UserData:Comment="{comment}"'
                 ]
             elif ext in {'.heic', '.jpg', '.jpeg', '.png'}:
                 cmd += [
-                    f'-AllDates="{dt}',
-                    f'-XPComment="{comment}'
+                    f'-AllDates="{dt}"',
+                    f'-XPComment="{comment}"'
                 ]
 
             if inject_geo:


### PR DESCRIPTION
## Summary
- quote timestamp and comment arguments so exiftool parses them correctly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749469c15883279b55140bce09e6e9