### PR TITLE
Add pyexiftool integration and Swift launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ __pycache__/
 *.pyc
 *.pyo
 
+# Virtual environments
+venv/
+
 # 🤖 Codex + test logs (optional)
 debug_report.txt
 codex_session_notes.md

--- a/PhotoMetadataGUI.swift
+++ b/PhotoMetadataGUI.swift
@@ -71,10 +71,11 @@ struct ContentView: View {
         if dryRun { args.append("--dry-run") }
         if !outputPath.isEmpty { args += ["--output", outputPath] }
 
+        let python = ProcessInfo.processInfo.environment["PYTHON_EXECUTABLE"] ?? "python3"
         DispatchQueue.global().async {
             let task = Process()
             task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            task.arguments = ["python3"] + args
+            task.arguments = [python] + args
 
             let pipe = Pipe()
             task.standardOutput = pipe

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This utility processes the JSON metadata that accompanies a Google Photos export
   ```bash
   brew install exiftool
   ```
+- [`pyexiftool`](https://pypi.org/project/pyexiftool/) installed in a Python virtual environment. Run `launch_swift_gui.command` to set up the environment automatically.
 
 ## Usage
 Run the script and pass the path to your extracted Google Photos export. By default it will modify the files in place. Use `--dry-run` to generate the log and batch file without running `exiftool`.
@@ -33,7 +34,7 @@ python3 photo_metadata_patch.py /path/to/export --output /tmp/report.csv
 Double‑click the `launch_gui.command` file for the original Tkinter interface. It lets you choose the export folder and optional CSV destination. Make sure your photos aren’t open in other apps so Finder doesn’t lock them.
 
 ### SwiftUI
-For a macOS‑native interface built with SwiftUI, open `PhotoMetadataGUI.swift` in Xcode (macOS Sequoia or later) and run the app. The Swift version mirrors the Python GUI and invokes `photo_metadata_patch.py` behind the scenes.
+For a macOS-native interface built with SwiftUI, run `launch_swift_gui.command`. The script sets up a Python virtual environment with `pyexiftool` and then opens `PhotoMetadataGUI.swift` in Xcode. The Swift version mirrors the Python GUI and invokes `photo_metadata_patch.py` behind the scenes using the venv's Python interpreter.
 
 ## Testing
 Basic unit tests are located in the `tests` directory and can be run with:

--- a/launch_swift_gui.command
+++ b/launch_swift_gui.command
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Setup venv and open Swift GUI
+cd "$(dirname "$0")"
+if [ ! -d venv ]; then
+    python3 -m venv venv
+    ./venv/bin/pip install -r requirements.txt
+fi
+source venv/bin/activate
+export PYTHON_EXECUTABLE="$(pwd)/venv/bin/python"
+open -a Xcode PhotoMetadataGUI.swift

--- a/photo_metadata_patch.py
+++ b/photo_metadata_patch.py
@@ -2,13 +2,16 @@ import os
 import json
 import csv
 import shutil
-import subprocess
 from pathlib import Path
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor
 import sys
 import argparse
 import shlex
+try:
+    from exiftool import ExifTool
+except ImportError:  # graceful fallback for environments without pyexiftool
+    ExifTool = None
 
 def flatten_json(y, parent_key='', sep=':'):
     items = {}
@@ -88,44 +91,37 @@ def get_duplicate_type(matches, metadata_url, media_index):
         return "Exact Duplicate" if len(matches) > 1 else "Unique"
     return "Misleading Duplicate"
 
-def prepare_exiftool_batch(commands, batch_file_path):
-    with open(batch_file_path, "w", encoding="utf-8") as f:
-        for cmd_list in commands:
-            for arg in cmd_list:
-                f.write(arg + "\n")
-
 def apply_metadata_batch(batch_commands, dry_run):
     """Execute a batch of exiftool commands unless dry_run is True."""
     if dry_run or not batch_commands:
         return True
 
     if not shutil.which("exiftool"):
-        print("Error: 'exiftool' not found. Please install exiftool and ensure it is in your PATH.", file=sys.stderr)
+        print(
+            "Error: 'exiftool' not found. Please install exiftool and ensure it is in your PATH.",
+            file=sys.stderr,
+        )
         return False
 
-    batch_file = Path("exiftool_batch.txt")
-    prepare_exiftool_batch(batch_commands, batch_file)
+    if ExifTool is None:
+        print("Error: pyexiftool not installed", file=sys.stderr)
+        return False
+
     try:
-        # Let exiftool write output directly to the console. Capturing stdout and
-        # stderr can cause the process to hang if large amounts of data are
-        # produced, so we rely on the parent's standard streams instead.
         print(f"Executing exiftool with {len(batch_commands)} commands")
         if dry_run:
             print("\n--- Batch Commands Preview ---")
             for cmd in batch_commands:
                 print(cmd)
+            return True
 
-        subprocess.run(
-            ["exiftool", "-@", str(batch_file), "-overwrite_original"], check=True
-        )
+        with ExifTool() as et:
+            for cmd in batch_commands:
+                et.execute(*[c.encode() for c in cmd])
         return True
-    except subprocess.CalledProcessError as e:
+    except Exception as e:
         print(f"Exiftool batch error: {e}", file=sys.stderr)
         return False
-
-    finally:
-        if batch_file.exists():
-            batch_file.unlink()
 
 def process_metadata_files(project_root, dry_run=True, parallel_workers=4, output_path=None):
     """Process all JSON metadata files under project_root."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyexiftool


### PR DESCRIPTION
## Summary
- integrate `pyexiftool` with graceful fallback
- launch Swift GUI from a script that sets up a venv
- read Python interpreter path from `PYTHON_EXECUTABLE`
- document new requirements and launcher
- ignore local `venv` directory

## Testing
- `python3 -m unittest discover -s tests`
- ❌ `pip install pyexiftool` *(failed: cannot access pypi)*

------
https://chatgpt.com/codex/tasks/task_e_687534bb51888327ace812c62015f7a3