### PR TITLE
Fix dry-run preview and early return

### DIFF
--- a/photo_metadata_patch.py
+++ b/photo_metadata_patch.py
@@ -92,8 +92,15 @@ def get_duplicate_type(matches, metadata_url, media_index):
     return "Misleading Duplicate"
 
 def apply_metadata_batch(batch_commands, dry_run):
-    """Execute a batch of exiftool commands unless dry_run is True."""
-    if dry_run or not batch_commands:
+    """Execute a batch of exiftool commands or preview them when dry_run."""
+    if not batch_commands:
+        return True
+
+    print(f"Prepared {len(batch_commands)} exiftool commands")
+    if dry_run:
+        print("\n--- Batch Commands Preview ---")
+        for cmd in batch_commands:
+            print(" ".join(shlex.quote(c) for c in cmd))
         return True
 
     if not shutil.which("exiftool"):
@@ -109,12 +116,6 @@ def apply_metadata_batch(batch_commands, dry_run):
 
     try:
         print(f"Executing exiftool with {len(batch_commands)} commands")
-        if dry_run:
-            print("\n--- Batch Commands Preview ---")
-            for cmd in batch_commands:
-                print(cmd)
-            return True
-
         with ExifTool() as et:
             for cmd in batch_commands:
                 et.execute(*[c.encode() for c in cmd])


### PR DESCRIPTION
## Summary
- show preview of ExifTool commands in dry-run mode before running anything
- skip running ExifTool when no commands are queued

## Testing
- `python3 -m py_compile photo_metadata_patch.py`
- `python3 -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6879d15f52ec8327a5e82ebd6299263b