### PR TITLE
Fix duplicate CSV columns

### DIFF
--- a/photo_metadata_patch.py
+++ b/photo_metadata_patch.py
@@ -231,6 +231,8 @@ def process_metadata_files(project_root, dry_run=True, parallel_workers=4, outpu
                 note = "Dry run only"
 
         flat_json = flatten_json(data)
+        for key in ["title", "url"]:
+            flat_json.pop(key, None)
         row = {
             "JSON Filename": file,
             "Matched Media": match.name,
@@ -241,7 +243,7 @@ def process_metadata_files(project_root, dry_run=True, parallel_workers=4, outpu
             "File Size in bytes": size,
             "Notes": note,
             "Missing Fields": ", ".join(missing_fields),
-            **flat_json  # injects all flattened JSON keys
+            **flat_json  # injects all flattened JSON keys except duplicates
         }
         return row
 

--- a/tests/test_photo_metadata_patch.py
+++ b/tests/test_photo_metadata_patch.py
@@ -86,6 +86,25 @@ class TestPhotoMetadataPatch(unittest.TestCase):
             self.assertTrue(cmds and all(cmd[0] == "-overwrite_original_in_place" for cmd in cmds))
         report.unlink()
 
+    def test_csv_header_deduplicates_title_url(self):
+        report = Path("tests/output.csv")
+        if report.exists():
+            report.unlink()
+        with patch("photo_metadata_patch.apply_metadata_batch") as mock_apply:
+            mock_apply.return_value = True
+            process_metadata_files(
+                "tests",
+                dry_run=True,
+                parallel_workers=1,
+                output_path=report,
+            )
+        header = report.read_text(encoding="utf-8").splitlines()[0].split(",")
+        self.assertIn("Title", header)
+        self.assertIn("URL", header)
+        self.assertNotIn("title", header)
+        self.assertNotIn("url", header)
+        report.unlink()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- avoid reinserting `title` and `url` when flattening metadata
- add regression test ensuring CSV header only includes canonical Title/URL columns

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b140d214c8327b442d5f8ff944273